### PR TITLE
Fix pagination -  Always take the same number of pages

### DIFF
--- a/DotNetPaging/DotNetPaging.AspNetCore/Startup.cs
+++ b/DotNetPaging/DotNetPaging.AspNetCore/Startup.cs
@@ -22,7 +22,10 @@ namespace DotNetPaging.AspNetCore
         public void ConfigureServices(IServiceCollection services)
         {
             services.AddDbContext<DotNetPagingDbContext>(options =>
-                    options.UseSqlServer(Configuration.GetConnectionString("DefaultConnection")));
+                    options.UseSqlServer(
+                                            Configuration.GetConnectionString("DefaultConnection"), 
+                                            sqlServerOptions => sqlServerOptions.UseRowNumberForPaging()) //nedded only for SQL Server versions prior to SQL Server 2012
+                                        );
 
             services.AddAutoMapper();
             services.AddMvc();

--- a/DotNetPaging/DotNetPaging.AspNetCore/TagHelpers/PagerTagHelper.cs
+++ b/DotNetPaging/DotNetPaging.AspNetCore/TagHelpers/PagerTagHelper.cs
@@ -40,6 +40,11 @@ namespace DotNetPaging.AspNetCore.TagHelpers
                 return;
             }
 
+            //Number of pages to show in both sides of active page
+            // if you are to the beggining or to the end, and it is impossible to take PAGES_TO_SHOW (the value of variable as number) pages
+            // you can take them from the other side of active page to have always the same number of pages in pagination
+            var PAGES_TO_SHOW = 5;
+
             var action = ViewContext.RouteData.Values["action"].ToString();
             var urlTemplate = WebUtility.UrlDecode(_urlHelper.Action(action, new { page = "{0}" }));
             var request = _httpContext.Request;
@@ -53,8 +58,8 @@ namespace DotNetPaging.AspNetCore.TagHelpers
                 urlTemplate += "&" + key + "=" + request.Query[key];
             }
 
-            var startIndex = Math.Max(Model.CurrentPage - 5, 1);
-            var finishIndex = Math.Min(Model.CurrentPage + 5, Model.PageCount);
+            var startIndex = Math.Max((Model.CurrentPage - PAGES_TO_SHOW) - Math.Max(PAGES_TO_SHOW - (Model.PageCount - Model.CurrentPage), 0), 1);
+            var finishIndex = Math.Min(Model.CurrentPage + PAGES_TO_SHOW + Math.Max(PAGES_TO_SHOW - Model.CurrentPage + 1, 0), Model.PageCount);
 
             output.TagName = "";
             output.Content.AppendHtml("<ul class=\"pagination\">");

--- a/DotNetPaging/DotNetPaging.AspNetCore/Views/Shared/Components/Pager/Default.cshtml
+++ b/DotNetPaging/DotNetPaging.AspNetCore/Views/Shared/Components/Pager/Default.cshtml
@@ -1,5 +1,10 @@
 ﻿@model PagedResultBase
 @{
+    //Number of pages to show in both sides of active page
+    // if you are to the beggining or to the end, and it is impossible to take PAGES_TO_SHOW (the value of variable as number) pages
+    // you can take them from the other side of active page to have always the same number of pages in pagination
+    var PAGES_TO_SHOW = 5;
+
     var urlTemplate = Model.LinkTemplate;
     var request = ViewContext.HttpContext.Request;
     foreach (var key in request.Query.Keys)
@@ -12,8 +17,8 @@
         urlTemplate += "&" + key + "=" + request.Query[key];
     }
 
-    var startIndex = Math.Max(Model.CurrentPage - 5, 1);
-    var finishIndex = Math.Min(Model.CurrentPage + 5, Model.PageCount);
+    var startIndex = Math.Max((Model.CurrentPage - PAGES_TO_SHOW) - Math.Max(PAGES_TO_SHOW - (Model.PageCount - Model.CurrentPage), 0), 1);
+    var finishIndex = Math.Min(Model.CurrentPage + PAGES_TO_SHOW + Math.Max(PAGES_TO_SHOW - Model.CurrentPage + 1, 0), Model.PageCount);
 }
 
 <div class="row">


### PR DESCRIPTION
If there is no page to the left/right of active page, we get there
from the other side to have always the same number of pages shown.